### PR TITLE
Add user roles

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,49 +1,65 @@
--- Create the tables
+-- Group Service Schema
 CREATE TABLE groups
 (
-    group_id     VARCHAR(255) PRIMARY KEY,
-    group_name   VARCHAR(255),
-    description  TEXT,
-    creator_id   UUID,
-    time_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    group_id            VARCHAR(255) PRIMARY KEY,
+    group_name          VARCHAR(255),
+    description         TEXT,
+    creator_id          UUID,
+    time_created        TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE members
 (
-    user_id  UUID                                                        NOT NULL,
-    group_id VARCHAR(255) REFERENCES groups (group_id) ON DELETE CASCADE NOT NULL,
+    user_id         UUID NOT NULL,
+    group_id        VARCHAR(255) REFERENCES groups(group_id) ON DELETE CASCADE NOT NULL,
     PRIMARY KEY (group_id, user_id)
 );
 
 CREATE TABLE roles
 (
-    role_id SERIAL PRIMARY KEY,
-    role_name VARCHAR(255),
-    UNIQUE (role_name)
+    role_name VARCHAR(63) PRIMARY KEY
 );
 
 CREATE TABLE user_roles
 (
-    user_id  UUID REFERENCES members (user_id) ON DELETE CASCADE NOT NULL,
-    group_id VARCHAR(255) REFERENCES groups (group_id) ON DELETE CASCADE NOT NULL,
-    role_id  INT REFERENCES roles (role_id) ON DELETE CASCADE NOT NULL,
-    PRIMARY KEY (user_id, group_id, role_id)
+    user_id  UUID NOT NULL,
+    group_id VARCHAR(255) NOT NULL,
+    role_name  VARCHAR(63) REFERENCES roles (role_name) ON DELETE CASCADE NOT NULL,
+    PRIMARY KEY (user_id, group_id, role_name),
+    FOREIGN KEY (user_id, group_id) REFERENCES members (user_id, group_id) ON DELETE CASCADE
 );
 
-
 -- Insert sample data into the groups table
-INSERT INTO groups (group_id, group_name, description, creator_id)
-VALUES ('group_1', 'Developers', 'Group for developers to discuss and share knowledge.',
-        'a1e8a3d2-07a8-11ec-bf63-0242ac130002'),
-       ('group_2', 'Designers', 'Group for designers to collaborate on projects.',
-        'a1e8a3d2-07a8-11ec-bf63-0242ac130003'),
-       ('group_3', 'Managers', 'Group for managers to discuss strategies and plans.',
-        'a1e8a3d2-07a8-11ec-bf63-0242ac130004');
+INSERT INTO groups (group_id, group_name, description, creator_id, time_created) VALUES
+                                                                                     ('group1', 'Developers Group', 'Group for software developers.', 'c50b79b4-4bb2-4de6-9c3c-1d6cda63d672', '2024-08-14 10:00:00'),
+                                                                                     ('group2', 'Designers Group', 'Group for graphic and UI/UX designers.', 'c06b7b23-3e5a-4b64-8df3-f2cb4b4b2c6a', '2024-08-14 10:05:00'),
+                                                                                     ('group3', 'Product Managers Group', 'Group for product management professionals.', 'efbdcf0e-232f-47ba-93de-97284b71ad34', '2024-08-14 10:10:00'),
+                                                                                     ('group4', 'Marketing Group', 'Group for marketing professionals.', 'ba8c56f4-6b9d-41a6-9e78-9982f6fa7d48', '2024-08-14 10:15:00'),
+                                                                                     ('group5', 'Sales Group', 'Group for sales professionals.', 'd7d2179a-3dcb-4237-b8c4-39dc1f73df17', '2024-08-14 10:20:00');
 
 -- Insert sample data into the members table
-INSERT INTO members (user_id, group_id)
-VALUES ('a1e8a3d2-07a8-11ec-bf63-0242ac130005', 'group_1'),
-       ('a1e8a3d2-07a8-11ec-bf63-0242ac130006', 'group_1'),
-       ('a1e8a3d2-07a8-11ec-bf63-0242ac130007', 'group_2'),
-       ('a1e8a3d2-07a8-11ec-bf63-0242ac130008', 'group_2'),
-       ('a1e8a3d2-07a8-11ec-bf63-0242ac130009', 'group_3');
+INSERT INTO members (user_id, group_id) VALUES
+                                            ('b1f8e925-2129-473d-bc09-b3a2a331f839', 'group1'),
+                                            ('bcdbbd68-8975-41d9-bd55-4a30a9f8e5f7', 'group1'),
+                                            ('ca98fcb8-28b3-4708-becd-9114c9bba4b3', 'group1'),
+                                            ('9edc3d7f-b5cb-4e8b-9a9b-3b4b4d91bf0b', 'group2'),
+                                            ('3fb27438-8e71-4513-95d2-7c2c18b72b4a', 'group2'),
+                                            ('68839b0c-7e14-4b65-a95c-873edc8f31c9', 'group2'),
+                                            ('e63a9f56-3d7b-4a62-bf10-77b8f45b7ed6', 'group3'),
+                                            ('c19b9b3b-d60c-46fc-97e1-3c47c00c5727', 'group3'),
+                                            ('11c17138-839f-4189-8103-9d4031cf3765', 'group4'),
+                                            ('3d0d216a-3bf6-4078-b0b1-3b72c4b0a4a7', 'group4'),
+                                            ('823dbe18-c1ad-423e-a9f1-1c5b1931c095', 'group4'),
+                                            ('9bc8a7db-7f14-41a3-bf7e-d0a0078cfbab', 'group5'),
+                                            ('debfdbd5-bf68-46e2-bfc3-21d6fa4ddfe1', 'group5');
+
+-- Insert sample data into the roles table
+INSERT INTO roles (role_name) VALUES
+                                  ('Group Moderator'),
+                                  ('Group Admin');
+
+-- Insert sample data into the user_roles table
+INSERT INTO user_roles (user_id, group_id, role_name) VALUES
+                                                          ('b1f8e925-2129-473d-bc09-b3a2a331f839', 'group1', Group Admin),
+                                                          ('bcdbbd68-8975-41d9-bd55-4a30a9f8e5f7', 'group1', Group Moderator),
+                                                          ('ca98fcb8-28b3-4708-becd-9114c9bba4b3', 'group1', Group Moderator);

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -15,6 +15,22 @@ CREATE TABLE members
     PRIMARY KEY (group_id, user_id)
 );
 
+CREATE TABLE roles
+(
+    role_id   UUID PRIMARY KEY,
+    role_name VARCHAR(255),
+    UNIQUE (role_name)
+);
+
+CREATE TABLE user_roles
+(
+    user_id  UUID REFERENCES members (user_id) ON DELETE CASCADE NOT NULL,
+    group_id VARCHAR(255) REFERENCES groups (group_id) ON DELETE CASCADE NOT NULL,
+    role_id  UUID REFERENCES roles (role_id) ON DELETE CASCADE NOT NULL,
+    PRIMARY KEY (user_id, group_id, role_id)
+);
+
+
 -- Insert sample data into the groups table
 INSERT INTO groups (group_id, group_name, description, creator_id)
 VALUES ('group_1', 'Developers', 'Group for developers to discuss and share knowledge.',

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -17,7 +17,7 @@ CREATE TABLE members
 
 CREATE TABLE roles
 (
-    role_id   UUID PRIMARY KEY,
+    role_id SERIAL PRIMARY KEY,
     role_name VARCHAR(255),
     UNIQUE (role_name)
 );
@@ -26,7 +26,7 @@ CREATE TABLE user_roles
 (
     user_id  UUID REFERENCES members (user_id) ON DELETE CASCADE NOT NULL,
     group_id VARCHAR(255) REFERENCES groups (group_id) ON DELETE CASCADE NOT NULL,
-    role_id  UUID REFERENCES roles (role_id) ON DELETE CASCADE NOT NULL,
+    role_id  INT REFERENCES roles (role_id) ON DELETE CASCADE NOT NULL,
     PRIMARY KEY (user_id, group_id, role_id)
 );
 

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
@@ -1,6 +1,7 @@
 package com.MTAPizza.Sympoll.groupmanagementservice.controller;
 
 import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.GroupCreateRequest;
+import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.UserRoleChangeRequest;
 import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.UserRoleCreateRequest;
 import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.UserRoleDeleteRequest;
 import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.*;
@@ -100,7 +101,7 @@ ServiceController {
 
     /**
      * Add a new role to a user in specific group.
-     * @param userRoleCreateRequest Contain the user id, group id and role id.
+     * @param userRoleCreateRequest Contain the user id, group id and role name.
      * @return A DTO object with the user id and his new role name.
      */
     @PostMapping("/user-role")
@@ -124,8 +125,20 @@ ServiceController {
     }
 
     /**
+     * Change the given user's role in specific group.
+     * @param userRoleChangeRequest Contain the user id, group id and the new role name.
+     * @return The previous user's role name.
+     */
+    @PutMapping("/user-role")
+    @ResponseStatus(HttpStatus.OK)
+    public String changeUserRole(@RequestBody UserRoleChangeRequest userRoleChangeRequest) {
+        log.info("Received a request to change user role");
+        return userRolesService.changeUserRole(userRoleChangeRequest.userId(), userRoleChangeRequest.groupId(), userRoleChangeRequest.newRoleName());
+    }
+
+    /**
      * Delete a user role from the database.
-     * @param userRoleDeleteRequest Contain the user id, group id and role id.
+     * @param userRoleDeleteRequest Contain the user id, group id and role name.
      * @return A DTO with the user id and his deleted role name.
      */
     @DeleteMapping("/user-role")

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
@@ -107,20 +107,7 @@ ServiceController {
     @ResponseStatus(HttpStatus.CREATED)
     public UserRoleResponse createUserRole(@RequestBody UserRoleCreateRequest userRoleCreateRequest) {
         log.info("Received a request to create a user role");
-        return userRolesService.createUserRole(userRoleCreateRequest.userId(), userRoleCreateRequest.groupId(), userRoleCreateRequest.roleId());
-    }
-
-    /**
-     * Return the given user's role id in specific group.
-     * @param userId Given user ID.
-     * @param groupId Given group ID.
-     * @return The ID of the user's role in the given group.
-     */
-    @GetMapping("/user-role/id")
-    @ResponseStatus(HttpStatus.OK)
-    public int getRoleIdOfSpecificUser(@RequestParam UUID userId, @RequestParam String groupId) {
-        log.info("Received a request to get role id of specific user");
-        return userRolesService.getRoleIdOfSpecificUser(userId, groupId);
+        return userRolesService.createUserRole(userRoleCreateRequest.userId(), userRoleCreateRequest.groupId(), userRoleCreateRequest.roleName());
     }
 
     /**
@@ -129,7 +116,7 @@ ServiceController {
      * @param groupId Given group ID.
      * @return The name of the user's role in the given group.
      */
-    @GetMapping("/user-role/name")
+    @GetMapping("/user-role")
     @ResponseStatus(HttpStatus.OK)
     public String getRoleNameOfSpecificUser(@RequestParam UUID userId, @RequestParam String groupId) {
         log.info("Received a request to get role name of specific user");
@@ -145,6 +132,6 @@ ServiceController {
     @ResponseStatus(HttpStatus.OK)
     public UserRoleDeleteResponse deleteUserRole(@RequestBody UserRoleDeleteRequest userRoleDeleteRequest) {
         log.info("Received a request to delete user role");
-        return userRolesService.deleteUserRole(userRoleDeleteRequest.userId(), userRoleDeleteRequest.groupId(), userRoleDeleteRequest.roleId());
+        return userRolesService.deleteUserRole(userRoleDeleteRequest.userId(), userRoleDeleteRequest.groupId(), userRoleDeleteRequest.roleName());
     }
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
@@ -79,6 +79,11 @@ ServiceController {
         return new DeleteGroupResponse(groupService.deleteGroup(groupId));
     }
 
+    /**
+     * Verifying the given group ID exists in the database.
+     * @param groupId A group ID to verify.
+     * @return A DTO with 'isExists' boolean value.
+     */
     @GetMapping("/id")
     @ResponseStatus(HttpStatus.OK)
     public GroupIdExistsResponse checkGroupIdExists(@RequestParam String groupId) {;
@@ -93,6 +98,11 @@ ServiceController {
         return "OK";
     }
 
+    /**
+     * Add a new role to a user in specific group.
+     * @param userRoleCreateRequest Contain the user id, group id and role id.
+     * @return A DTO object with the user id and his new role name.
+     */
     @PostMapping("/user-role")
     @ResponseStatus(HttpStatus.CREATED)
     public UserRoleResponse createUserRole(@RequestBody UserRoleCreateRequest userRoleCreateRequest) {
@@ -100,6 +110,12 @@ ServiceController {
         return userRolesService.createUserRole(userRoleCreateRequest.userId(), userRoleCreateRequest.groupId(), userRoleCreateRequest.roleId());
     }
 
+    /**
+     * Return the given user's role id in specific group.
+     * @param userId Given user ID.
+     * @param groupId Given group ID.
+     * @return The ID of the user's role in the given group.
+     */
     @GetMapping("/user-role/id")
     @ResponseStatus(HttpStatus.OK)
     public int getRoleIdOfSpecificUser(@RequestParam UUID userId, @RequestParam String groupId) {
@@ -107,6 +123,12 @@ ServiceController {
         return userRolesService.getRoleIdOfSpecificUser(userId, groupId);
     }
 
+    /**
+     * Return the given user's role name in specific group.
+     * @param userId Given user ID.
+     * @param groupId Given group ID.
+     * @return The name of the user's role in the given group.
+     */
     @GetMapping("/user-role/name")
     @ResponseStatus(HttpStatus.OK)
     public String getRoleNameOfSpecificUser(@RequestParam UUID userId, @RequestParam String groupId) {
@@ -114,6 +136,11 @@ ServiceController {
         return userRolesService.getRoleNameOfSpecificUser(userId, groupId);
     }
 
+    /**
+     * Delete a user role from the database.
+     * @param userRoleDeleteRequest Contain the user id, group id and role id.
+     * @return A DTO with the user id and his deleted role name.
+     */
     @DeleteMapping("/user-role")
     @ResponseStatus(HttpStatus.OK)
     public UserRoleDeleteResponse deleteUserRole(@RequestBody UserRoleDeleteRequest userRoleDeleteRequest) {

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
@@ -18,7 +18,8 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/group")
 @RequiredArgsConstructor
-public class ServiceController {
+public class
+ServiceController {
     private final GroupService groupService;
     private final UserRolesService userRolesService;
 

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/controller/ServiceController.java
@@ -1,12 +1,11 @@
 package com.MTAPizza.Sympoll.groupmanagementservice.controller;
 
 import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.GroupCreateRequest;
-import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.GroupIdExistsRequest;
-import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.DeleteGroupResponse;
-import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.GroupIdExistsResponse;
-import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.GroupResponse;
-import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.MemberResponse;
+import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.UserRoleCreateRequest;
+import com.MTAPizza.Sympoll.groupmanagementservice.dto.request.UserRoleDeleteRequest;
+import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.*;
 import com.MTAPizza.Sympoll.groupmanagementservice.service.GroupService;
+import com.MTAPizza.Sympoll.groupmanagementservice.service.UserRolesService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -21,6 +20,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ServiceController {
     private final GroupService groupService;
+    private final UserRolesService userRolesService;
 
     /**
      * Add a new group to the database.
@@ -90,5 +90,33 @@ public class ServiceController {
     public String HealthCheck(){
         log.info("Received a request to health check");
         return "OK";
+    }
+
+    @PostMapping("/user-role")
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserRoleResponse createUserRole(@RequestBody UserRoleCreateRequest userRoleCreateRequest) {
+        log.info("Received a request to create a user role");
+        return userRolesService.createUserRole(userRoleCreateRequest.userId(), userRoleCreateRequest.groupId(), userRoleCreateRequest.roleId());
+    }
+
+    @GetMapping("/user-role/id")
+    @ResponseStatus(HttpStatus.OK)
+    public int getRoleIdOfSpecificUser(@RequestParam UUID userId, @RequestParam String groupId) {
+        log.info("Received a request to get role id of specific user");
+        return userRolesService.getRoleIdOfSpecificUser(userId, groupId);
+    }
+
+    @GetMapping("/user-role/name")
+    @ResponseStatus(HttpStatus.OK)
+    public String getRoleNameOfSpecificUser(@RequestParam UUID userId, @RequestParam String groupId) {
+        log.info("Received a request to get role name of specific user");
+        return userRolesService.getRoleNameOfSpecificUser(userId, groupId);
+    }
+
+    @DeleteMapping("/user-role")
+    @ResponseStatus(HttpStatus.OK)
+    public UserRoleDeleteResponse deleteUserRole(@RequestBody UserRoleDeleteRequest userRoleDeleteRequest) {
+        log.info("Received a request to delete user role");
+        return userRolesService.deleteUserRole(userRoleDeleteRequest.userId(), userRoleDeleteRequest.groupId(), userRoleDeleteRequest.roleId());
     }
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleChangeRequest.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleChangeRequest.java
@@ -1,0 +1,10 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.dto.request;
+
+import java.util.UUID;
+
+public record UserRoleChangeRequest(
+        UUID userId,
+        String groupId,
+        String newRoleName
+) {
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleCreateRequest.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleCreateRequest.java
@@ -1,0 +1,10 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.dto.request;
+
+import java.util.UUID;
+
+public record UserRoleCreateRequest(
+        UUID userId,
+        String groupId,
+        int roleId
+) {
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleCreateRequest.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleCreateRequest.java
@@ -5,6 +5,6 @@ import java.util.UUID;
 public record UserRoleCreateRequest(
         UUID userId,
         String groupId,
-        int roleId
+        String roleName
 ) {
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleDeleteRequest.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleDeleteRequest.java
@@ -1,0 +1,10 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.dto.request;
+
+import java.util.UUID;
+
+public record UserRoleDeleteRequest(
+        UUID userId,
+        String groupId,
+        int roleId
+) {
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleDeleteRequest.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/request/UserRoleDeleteRequest.java
@@ -5,6 +5,6 @@ import java.util.UUID;
 public record UserRoleDeleteRequest(
         UUID userId,
         String groupId,
-        int roleId
+        String roleName
 ) {
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/response/UserRoleDeleteResponse.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/response/UserRoleDeleteResponse.java
@@ -1,0 +1,9 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.dto.response;
+
+import java.util.UUID;
+
+public record UserRoleDeleteResponse(
+        UUID userId,
+        String roleName
+) {
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/response/UserRoleResponse.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/dto/response/UserRoleResponse.java
@@ -1,0 +1,9 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.dto.response;
+
+import java.util.UUID;
+
+public record UserRoleResponse (
+        UUID userId,
+        String roleName
+) {
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/member/id/MemberId.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/member/id/MemberId.java
@@ -1,10 +1,6 @@
 package com.MTAPizza.Sympoll.groupmanagementservice.model.member.id;
 
-
-import com.MTAPizza.Sympoll.groupmanagementservice.model.member.Member;
-import jakarta.persistence.Id;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 import java.io.Serializable;
 import java.util.Objects;

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/Role.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/Role.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class Role {
     @Id
-    private UUID roleId;
+    private int roleId;
 
     @Column(name = "role_name")
     private String roleName;

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/Role.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/Role.java
@@ -15,8 +15,6 @@ import java.util.UUID;
 @AllArgsConstructor
 public class Role {
     @Id
-    private int roleId;
-
     @Column(name = "role_name")
     private String roleName;
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/Role.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/Role.java
@@ -1,0 +1,22 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.model.role;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.UUID;
+
+@Entity
+@Table(name = "roles")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+    @Id
+    private UUID roleId;
+
+    @Column(name = "role_name")
+    private String roleName;
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
@@ -26,6 +26,6 @@ public class UserRole {
     private String groupId;
 
     @Id
-    @Column(name = "role_id")
-    private int roleId;
+    @Column(name = "role_name")
+    private String roleId;
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
@@ -27,5 +27,5 @@ public class UserRole {
 
     @Id
     @Column(name = "role_name")
-    private String roleId;
+    private String roleName;
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
@@ -27,5 +27,5 @@ public class UserRole {
 
     @Id
     @Column(name = "role_id")
-    private UUID roleId;
+    private int roleId;
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
@@ -3,6 +3,7 @@ package com.MTAPizza.Sympoll.groupmanagementservice.model.user.role;
 import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.id.UserRoleId;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import java.util.UUID;
 @Table(name = "user_roles")
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Data
 @IdClass(UserRoleId.class)
 public class UserRole {

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/UserRole.java
@@ -1,0 +1,29 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.model.user.role;
+
+import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.id.UserRoleId;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_roles")
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@IdClass(UserRoleId.class)
+public class UserRole {
+    @Id
+    @Column(name = "user_id")
+    private UUID userId;
+
+    @Id
+    @Column(name = "group_id")
+    private String groupId;
+
+    @Id
+    @Column(name = "role_id")
+    private UUID roleId;
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/id/UserRoleId.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/id/UserRoleId.java
@@ -11,18 +11,18 @@ public class UserRoleId implements Serializable {
 
     private UUID userId;
 
-    private int roleId;
+    private String roleName;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UserRoleId that = (UserRoleId) o;
-        return Objects.equals(groupId, that.groupId) && Objects.equals(userId, that.userId) && Objects.equals(roleId, that.roleId);
+        return Objects.equals(groupId, that.groupId) && Objects.equals(userId, that.userId) && Objects.equals(roleName, that.roleName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, userId, roleId);
+        return Objects.hash(groupId, userId, roleName);
     }
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/id/UserRoleId.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/id/UserRoleId.java
@@ -1,0 +1,28 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.id;
+
+import lombok.Data;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+@Data
+public class UserRoleId implements Serializable {
+    private String groupId;
+
+    private UUID userId;
+
+    private UUID roleId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserRoleId that = (UserRoleId) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(userId, that.userId) && Objects.equals(roleId, that.roleId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, userId, roleId);
+    }
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/id/UserRoleId.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/user/role/id/UserRoleId.java
@@ -11,7 +11,7 @@ public class UserRoleId implements Serializable {
 
     private UUID userId;
 
-    private UUID roleId;
+    private int roleId;
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/MemberRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/MemberRepository.java
@@ -1,11 +1,12 @@
 package com.MTAPizza.Sympoll.groupmanagementservice.repository;
 
 import com.MTAPizza.Sympoll.groupmanagementservice.model.member.Member;
+import com.MTAPizza.Sympoll.groupmanagementservice.model.member.id.MemberId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, UUID> {
+public interface MemberRepository extends JpaRepository<Member, MemberId> {
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
@@ -2,9 +2,11 @@ package com.MTAPizza.Sympoll.groupmanagementservice.repository;
 
 import com.MTAPizza.Sympoll.groupmanagementservice.model.role.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
+@Repository
 public interface RoleRepository extends JpaRepository<Role, Integer> {
 
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.repository;
+
+import com.MTAPizza.Sympoll.groupmanagementservice.model.role.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RoleRepository extends JpaRepository<Role, UUID> {
+
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface RoleRepository extends JpaRepository<Role, Integer> {
+public interface RoleRepository extends JpaRepository<Role, String> {
 
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/RoleRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface RoleRepository extends JpaRepository<Role, UUID> {
+public interface RoleRepository extends JpaRepository<Role, Integer> {
 
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/UserRoleRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/UserRoleRepository.java
@@ -3,9 +3,11 @@ package com.MTAPizza.Sympoll.groupmanagementservice.repository;
 import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.UserRole;
 import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.id.UserRoleId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
+@Repository
 public interface UserRoleRepository extends JpaRepository<UserRole, UserRoleId> {
     UserRole findByUserIdAndGroupId(UUID userId, String groupId);
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/UserRoleRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/UserRoleRepository.java
@@ -1,0 +1,8 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.repository;
+
+import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.UserRole;
+import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.id.UserRoleId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, UserRoleId> {
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/UserRoleRepository.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/repository/UserRoleRepository.java
@@ -4,5 +4,8 @@ import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.UserRole;
 import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.id.UserRoleId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.UUID;
+
 public interface UserRoleRepository extends JpaRepository<UserRole, UserRoleId> {
+    UserRole findByUserIdAndGroupId(UUID userId, String groupId);
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
@@ -111,6 +111,11 @@ public class GroupService {
         return groupId;
     }
 
+    /**
+     * Verifying the given group ID exists in the database
+     * @param groupId A group ID to verify
+     * @return True if the ID exists in the database. Otherwise, return false
+     */
     public boolean checkGroupIdExists(String groupId) {
         log.info("Checking if group with ID - '{}' exists", groupId);
         return groupRepository.existsById(groupId);

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/RoleService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/RoleService.java
@@ -14,8 +14,7 @@ import java.util.UUID;
 public class RoleService {
     private final RoleRepository roleRepository;
 
-    public Role getRole(UUID roleId) {
-        // TODO: validator methods
+    public Role getRole(int roleId) {
         log.info("Getting role with id {}", roleId);
         return roleRepository.getReferenceById(roleId);
     }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/RoleService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/RoleService.java
@@ -14,9 +14,9 @@ import java.util.UUID;
 public class RoleService {
     private final RoleRepository roleRepository;
 
-    public Role getRole(int roleId) {
-        log.info("Getting role with id {}", roleId);
-        return roleRepository.getReferenceById(roleId);
+    public Role getRole(String roleName) {
+        log.info("Getting role with id {}", roleName);
+        return roleRepository.getReferenceById(roleName);
     }
 
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/RoleService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/RoleService.java
@@ -1,0 +1,23 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.service;
+
+import com.MTAPizza.Sympoll.groupmanagementservice.model.role.Role;
+import com.MTAPizza.Sympoll.groupmanagementservice.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RoleService {
+    private final RoleRepository roleRepository;
+
+    public Role getRole(UUID roleId) {
+        // TODO: validator methods
+        log.info("Getting role with id {}", roleId);
+        return roleRepository.getReferenceById(roleId);
+    }
+
+}

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -35,7 +35,7 @@ public class UserRolesService {
 
     public int getRoleIdOfSpecificUser(UUID userId, String groupId) {
         //TODO: validation method
-        log.info("Get role id for {}", userId);
+        log.info("Get role id for {} from the group {}", userId, groupId);
         return userRoleRepository.findByUserIdAndGroupId(userId,groupId).getRoleId();
     }
 

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -22,34 +22,22 @@ public class UserRolesService {
      * Add a new role to a user in specific group.
      * @param userId Given user ID.
      * @param groupId Given group ID.
-     * @param roleId Given role ID.
+     * @param roleName Given role name.
      * @return A DTO object with the user id and his new role name.
      */
-    public UserRoleResponse createUserRole(UUID userId, String groupId, int roleId) {
+    public UserRoleResponse createUserRole(UUID userId, String groupId, String roleName) {
         //TODO: validation method
         log.info("Create user role for {}", userId);
 
         UserRole createdUserRole = UserRole.builder()
                 .userId(userId)
                 .groupId(groupId)
-                .roleId(roleId)
+                .roleId(roleName)
                 .build();
 
         userRoleRepository.save(createdUserRole);
         log.info("Created user role for {}", userId);
-        return new UserRoleResponse(userId, roleService.getRole(roleId).getRoleName());
-    }
-
-    /**
-     * Return the given user's role id in specific group.
-     * @param userId Given user ID.
-     * @param groupId Given group ID.
-     * @return The ID of the user's role in the given group.
-     */
-    public int getRoleIdOfSpecificUser(UUID userId, String groupId) {
-        //TODO: validation method
-        log.info("Get role id for {} from the group {}", userId, groupId);
-        return userRoleRepository.findByUserIdAndGroupId(userId,groupId).getRoleId();
+        return new UserRoleResponse(userId, roleService.getRole(roleName).getRoleName());
     }
 
     /**
@@ -61,23 +49,23 @@ public class UserRolesService {
     public String getRoleNameOfSpecificUser(UUID userId, String groupId) {
         //TODO: validation method
         log.info("Get role name for {}", userId);
-        int roleId = userRoleRepository.findByUserIdAndGroupId(userId, groupId).getRoleId();
-        return roleService.getRole(roleId).getRoleName();
+        String roleName = userRoleRepository.findByUserIdAndGroupId(userId, groupId).getRoleId();
+        return roleService.getRole(roleName).getRoleName();
     }
 
     /**
      * Delete a user role from the database.
      * @param userId Given user ID.
      * @param groupId Given group ID.
-     * @param roleId Given role ID.
+     * @param roleName Given role name.
      * @return A DTO with the user id and his deleted role name.
      */
-    public UserRoleDeleteResponse deleteUserRole(UUID userId, String groupId, int roleId) {
+    public UserRoleDeleteResponse deleteUserRole(UUID userId, String groupId, String roleName) {
         //TODO: validation method
         log.info("Delete user role for {}", userId);
         UserRole userRole = userRoleRepository.findByUserIdAndGroupId(userId, groupId);
         userRoleRepository.delete(userRole);
         log.info("Deleted user role for {}", userId);
-        return new UserRoleDeleteResponse(userId, roleService.getRole(roleId).getRoleName());
+        return new UserRoleDeleteResponse(userId, roleService.getRole(roleName).getRoleName());
     }
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -18,6 +18,13 @@ public class UserRolesService {
     private final UserRoleRepository userRoleRepository;
     private final RoleService roleService;
 
+    /**
+     * Add a new role to a user in specific group.
+     * @param userId Given user ID.
+     * @param groupId Given group ID.
+     * @param roleId Given role ID.
+     * @return A DTO object with the user id and his new role name.
+     */
     public UserRoleResponse createUserRole(UUID userId, String groupId, int roleId) {
         //TODO: validation method
         log.info("Create user role for {}", userId);
@@ -33,12 +40,24 @@ public class UserRolesService {
         return new UserRoleResponse(userId, roleService.getRole(roleId).getRoleName());
     }
 
+    /**
+     * Return the given user's role id in specific group.
+     * @param userId Given user ID.
+     * @param groupId Given group ID.
+     * @return The ID of the user's role in the given group.
+     */
     public int getRoleIdOfSpecificUser(UUID userId, String groupId) {
         //TODO: validation method
         log.info("Get role id for {} from the group {}", userId, groupId);
         return userRoleRepository.findByUserIdAndGroupId(userId,groupId).getRoleId();
     }
 
+    /**
+     * Return the given user's role name in specific group.
+     * @param userId Given user ID.
+     * @param groupId Given group ID.
+     * @return The name of the user's role in the given group.
+     */
     public String getRoleNameOfSpecificUser(UUID userId, String groupId) {
         //TODO: validation method
         log.info("Get role name for {}", userId);
@@ -46,6 +65,13 @@ public class UserRolesService {
         return roleService.getRole(roleId).getRoleName();
     }
 
+    /**
+     * Delete a user role from the database.
+     * @param userId Given user ID.
+     * @param groupId Given group ID.
+     * @param roleId Given role ID.
+     * @return A DTO with the user id and his deleted role name.
+     */
     public UserRoleDeleteResponse deleteUserRole(UUID userId, String groupId, int roleId) {
         //TODO: validation method
         log.info("Delete user role for {}", userId);

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -15,8 +15,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Service
 public class UserRolesService {
-    private UserRoleRepository userRoleRepository;
-    private RoleService roleService;
+    private final UserRoleRepository userRoleRepository;
+    private final RoleService roleService;
 
     public UserRoleResponse createUserRole(UUID userId, String groupId, int roleId) {
         //TODO: validation method

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -32,7 +32,7 @@ public class UserRolesService {
         UserRole createdUserRole = UserRole.builder()
                 .userId(userId)
                 .groupId(groupId)
-                .roleId(roleName)
+                .roleName(roleName)
                 .build();
 
         userRoleRepository.save(createdUserRole);
@@ -49,8 +49,34 @@ public class UserRolesService {
     public String getRoleNameOfSpecificUser(UUID userId, String groupId) {
         //TODO: validation method
         log.info("Get role name for {}", userId);
-        String roleName = userRoleRepository.findByUserIdAndGroupId(userId, groupId).getRoleId();
+        String roleName = userRoleRepository.findByUserIdAndGroupId(userId, groupId).getRoleName();
         return roleService.getRole(roleName).getRoleName();
+    }
+
+    /**
+     *
+     * @param userRoleChangeRequest Contain the user id, group id and the new role name.
+     * @return
+     */
+
+    /**
+     * Change the given user's role in specific group.
+     * @param userId Given user ID.
+     * @param groupId Given group ID.
+     * @param newRoleName Given new role name.
+     * @return The previous user's role name.
+     */
+    public String changeUserRole(UUID userId, String groupId, String newRoleName) {
+        //TODO: validation method
+        String previousRoleName;
+
+        log.info("Change user role for {}", userId);
+        UserRole userRole = userRoleRepository.findByUserIdAndGroupId(userId, groupId);
+        previousRoleName = userRole.getRoleName();
+        userRole.setRoleName(newRoleName);
+        userRoleRepository.save(userRole);
+        log.info("Changed user role for {}", userId);
+        return previousRoleName;
     }
 
     /**

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -18,7 +18,7 @@ public class UserRolesService {
     private UserRoleRepository userRoleRepository;
     private RoleService roleService;
 
-    public UserRoleResponse createUserRole(UUID userId, String groupId, UUID roleId) {
+    public UserRoleResponse createUserRole(UUID userId, String groupId, int roleId) {
         //TODO: validation method
         log.info("Create user role for {}", userId);
 
@@ -33,7 +33,7 @@ public class UserRolesService {
         return new UserRoleResponse(userId, roleService.getRole(roleId).getRoleName());
     }
 
-    public UUID getRoleIdOfSpecificUser(UUID userId, String groupId) {
+    public int getRoleIdOfSpecificUser(UUID userId, String groupId) {
         //TODO: validation method
         log.info("Get role id for {}", userId);
         return userRoleRepository.findByUserIdAndGroupId(userId,groupId).getRoleId();
@@ -42,11 +42,11 @@ public class UserRolesService {
     public String getRoleNameOfSpecificUser(UUID userId, String groupId) {
         //TODO: validation method
         log.info("Get role name for {}", userId);
-        UUID roleId = userRoleRepository.findByUserIdAndGroupId(userId, groupId).getRoleId();
+        int roleId = userRoleRepository.findByUserIdAndGroupId(userId, groupId).getRoleId();
         return roleService.getRole(roleId).getRoleName();
     }
 
-    public UserRoleDeleteResponse deleteUserRole(UUID userId, String groupId, UUID roleId) {
+    public UserRoleDeleteResponse deleteUserRole(UUID userId, String groupId, int roleId) {
         //TODO: validation method
         log.info("Delete user role for {}", userId);
         UserRole userRole = userRoleRepository.findByUserIdAndGroupId(userId, groupId);
@@ -54,6 +54,4 @@ public class UserRolesService {
         log.info("Deleted user role for {}", userId);
         return new UserRoleDeleteResponse(userId, roleService.getRole(roleId).getRoleName());
     }
-
-
 }

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -1,0 +1,59 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.service;
+
+
+import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.UserRoleDeleteResponse;
+import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.UserRoleResponse;
+import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.UserRole;
+import com.MTAPizza.Sympoll.groupmanagementservice.repository.UserRoleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserRolesService {
+    private UserRoleRepository userRoleRepository;
+    private RoleService roleService;
+
+    public UserRoleResponse createUserRole(UUID userId, String groupId, UUID roleId) {
+        //TODO: validation method
+        log.info("Create user role for {}", userId);
+
+        UserRole createdUserRole = UserRole.builder()
+                .userId(userId)
+                .groupId(groupId)
+                .roleId(roleId)
+                .build();
+
+        userRoleRepository.save(createdUserRole);
+        log.info("Created user role for {}", userId);
+        return new UserRoleResponse(userId, roleService.getRole(roleId).getRoleName());
+    }
+
+    public UUID getRoleIdOfSpecificUser(UUID userId, String groupId) {
+        //TODO: validation method
+        log.info("Get role id for {}", userId);
+        return userRoleRepository.findByUserIdAndGroupId(userId,groupId).getRoleId();
+    }
+
+    public String getRoleNameOfSpecificUser(UUID userId, String groupId) {
+        //TODO: validation method
+        log.info("Get role name for {}", userId);
+        UUID roleId = userRoleRepository.findByUserIdAndGroupId(userId, groupId).getRoleId();
+        return roleService.getRole(roleId).getRoleName();
+    }
+
+    public UserRoleDeleteResponse deleteUserRole(UUID userId, String groupId, UUID roleId) {
+        //TODO: validation method
+        log.info("Delete user role for {}", userId);
+        UserRole userRole = userRoleRepository.findByUserIdAndGroupId(userId, groupId);
+        userRoleRepository.delete(userRole);
+        log.info("Deleted user role for {}", userId);
+        return new UserRoleDeleteResponse(userId, roleService.getRole(roleId).getRoleName());
+    }
+
+
+}


### PR DESCRIPTION
- Added new two tables:

   1. roles: stores the role's name only.
   2. user_roles: map users to roles within a specific group.

- Created JPA entities, repositories and services for the new tables.
- Currently, the available methods are: Create user role, get user's role name, change user's role, delete user role.