### PR TITLE
Fix spaces issue in group and role name enum

### DIFF
--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/RoleName.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/model/role/RoleName.java
@@ -1,0 +1,14 @@
+package com.MTAPizza.Sympoll.groupmanagementservice.model.role;
+
+import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.UserRole;
+
+public enum RoleName {
+    ADMIN,
+    MODERATOR;
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase();
+    }
+}
+

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
@@ -32,7 +32,7 @@ public class GroupService {
     @Transactional
     public GroupResponse createGroup(GroupCreateRequest groupCreateRequest) {
         log.info("Creating group {}", groupCreateRequest);
-        String fixedSpacesGroupName = groupCreateRequest.groupName().replace(" ", "-");
+        String fixedSpacesGroupName = groupCreateRequest.groupName().toLowerCase().replace(" ", "-");
 
         Group createdGroup = Group.builder()
                 .groupId(!groupRepository.existsById(fixedSpacesGroupName) ? fixedSpacesGroupName : UUID.randomUUID().toString().replaceAll("[^0-9]", "")) // If defined a group ID then use it, otherwise generate random group ID.

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
@@ -31,9 +31,10 @@ public class GroupService {
     @Transactional
     public GroupResponse createGroup(GroupCreateRequest groupCreateRequest) {
         log.info("Creating group {}", groupCreateRequest);
+        String fixedSpacesGroupName = groupCreateRequest.groupName().replace(" ", "-");
 
         Group createdGroup = Group.builder()
-                .groupId(!groupRepository.existsById(groupCreateRequest.groupName()) ? groupCreateRequest.groupName() : UUID.randomUUID().toString().replaceAll("[^0-9]", "")) // If defined a group ID then use it, otherwise generate random group ID.
+                .groupId(!groupRepository.existsById(fixedSpacesGroupName) ? fixedSpacesGroupName : UUID.randomUUID().toString().replaceAll("[^0-9]", "")) // If defined a group ID then use it, otherwise generate random group ID.
                 .groupName(groupCreateRequest.groupName())
                 .description(groupCreateRequest.description())
                 .creatorId(groupCreateRequest.creatorId())

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/GroupService.java
@@ -6,6 +6,7 @@ import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.MemberResponse;
 import com.MTAPizza.Sympoll.groupmanagementservice.exception.found.ResourceNotFoundException;
 import com.MTAPizza.Sympoll.groupmanagementservice.model.Group;
 import com.MTAPizza.Sympoll.groupmanagementservice.model.member.Member;
+import com.MTAPizza.Sympoll.groupmanagementservice.model.role.RoleName;
 import com.MTAPizza.Sympoll.groupmanagementservice.repository.GroupRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +51,7 @@ public class GroupService {
         log.info("User with ID - '{}' added to the new group as a member", creator.getUserId());
 
         // Set the creator to be group admin
-        userRolesService.createUserRole(createdGroup.getCreatorId(), createdGroup.getGroupId(), "Group Admin");
+        userRolesService.createUserRole(createdGroup.getCreatorId(), createdGroup.getGroupId(), RoleName.ADMIN.toString());
         log.info("User with ID - '{}' set as admin in the new group", creator.getUserId());
 
         groupRepository.save(createdGroup);

--- a/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
+++ b/src/main/java/com/MTAPizza/Sympoll/groupmanagementservice/service/UserRolesService.java
@@ -3,6 +3,7 @@ package com.MTAPizza.Sympoll.groupmanagementservice.service;
 
 import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.UserRoleDeleteResponse;
 import com.MTAPizza.Sympoll.groupmanagementservice.dto.response.UserRoleResponse;
+import com.MTAPizza.Sympoll.groupmanagementservice.model.role.RoleName;
 import com.MTAPizza.Sympoll.groupmanagementservice.model.user.role.UserRole;
 import com.MTAPizza.Sympoll.groupmanagementservice.repository.UserRoleRepository;
 import lombok.RequiredArgsConstructor;
@@ -107,7 +108,7 @@ public class UserRolesService {
         UserRole userRole = userRoleRepository.findByUserIdAndGroupId(userId, groupId);
         boolean result = false;
 
-        if(userRole.getRoleName().equals("Group Moderator") || userRole.getRoleName().equals("Group Admin")){
+        if(userRole.getRoleName().equals(RoleName.MODERATOR.toString()) || userRole.getRoleName().equals(RoleName.ADMIN.toString())){
             result = true;
         }else {
             //TODO: handle costume role permissions verification.


### PR DESCRIPTION
- 'createGroup' method now replace the spaces with '-' in every received group name
- Added role name enum and replaced every interaction with hard coded user roles name in the system